### PR TITLE
Use string,replace() to avoid backslash error in regex on Windows

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/sources/SourceCache.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/sources/SourceCache.java
@@ -247,7 +247,7 @@ public abstract class SourceCache {
         String fileSeparator = filePath.getFileSystem().getSeparator();
         String newSeparator = root.getFileSystem().getSeparator();
         if (!fileSeparator.equals(newSeparator)) {
-            filePathString = filePathString.replaceAll(fileSeparator, newSeparator);
+            filePathString = filePathString.replace(fileSeparator, newSeparator);
         }
         return root.resolve(filePathString);
     }


### PR DESCRIPTION
On Windows, the file separator character is defined as backslash.  Unfortunately, String.replaceAll() takes a regex, in which backslash has special meaning, causing this code to die with a PatternSyntaxException.

This PR uses String.replace() instead, which (sadly) uses regex under the hood, but properly escaped.
